### PR TITLE
Update MySQL Create DB Script with command supported in later MySQL Versions

### DIFF
--- a/data/storage/mysql/create_db_with_users.sql
+++ b/data/storage/mysql/create_db_with_users.sql
@@ -5,5 +5,6 @@
 
 DROP DATABASE IF EXISTS cgrates;
 CREATE DATABASE cgrates;
-
-GRANT ALL on cgrates.* TO 'cgrates'@'localhost' IDENTIFIED BY 'CGRateS.org';
+CREATE USER 'cgrates'@'localhost' IDENTIFIED BY 'CGRateS.org';
+GRANT ALL PRIVILEGES ON cgrates.* TO 'cgrates'@'localhost' WITH GRANT OPTION;
+FLUSH PRIVILEGES;


### PR DESCRIPTION
MySQL 8 removes support for the ability to create a user and grant privileges in the same transaction / query, which was used by the ./setup_cgr_db.sh script.

This is what we had before and works fine on older versions, but will not run on MySQL 8 and later:
`GRANT ALL on cgrates.* TO 'cgrates'@'localhost' IDENTIFIED BY 'CGRateS.org';`

Instead I have updated it to
```
CREATE USER 'cgrates'@'localhost' IDENTIFIED BY 'CGRateS.org';
GRANT ALL PRIVILEGES ON cgrates.* TO 'cgrates'@'localhost' WITH GRANT OPTION;
FLUSH PRIVILEGES;
```
Which should work across all versions of MySQL.